### PR TITLE
Fix build on recent nightly compilers (upgrade packed_simd)

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,7 +11,7 @@ license-file = "LICENSE"
 keywords = ["zkSNARKs", "cryptography", "proofs"]
 
 [dependencies]
-curve25519-dalek = { version = "2", features = ["serde", "simd_backend"]}
+curve25519-dalek = { version = "3", features = ["serde", "simd_backend"]}
 merlin = "2.0.0"
 rand = "0.7.3"
 digest = "0.8.1"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,8 +10,13 @@ repository = "https://github.com/microsoft/Spartan"
 license-file = "LICENSE"
 keywords = ["zkSNARKs", "cryptography", "proofs"]
 
+[dependencies.curve25519-dalek]
+features = ["serde", "simd_backend"]
+#version = "3"
+git = "https://github.com/dalek-cryptography/curve25519-dalek"
+rev = "a787300ba169ae035bcdf2d540cf2b61b950405c"
+
 [dependencies]
-curve25519-dalek = { version = "3", features = ["serde", "simd_backend"]}
 merlin = "2.0.0"
 rand = "0.7.3"
 digest = "0.8.1"


### PR DESCRIPTION
`packed_simd` version `0.3.3` fails to compile on recent nightly compilers and, transitively, so do releases of `curve25519-dalek` that use that version (https://github.com/dalek-cryptography/curve25519-dalek/issues/333). This has been fixed in their `develop` branch. The next release (probably `3.1.0`) should include the fix (and then a new version of this package using it should be published), but until then, I've pinned `curve25519-dalek` to [the commit fixing the issue](https://github.com/dalek-cryptography/curve25519-dalek/commit/a787300ba169ae035bcdf2d540cf2b61b950405c).