### PR TITLE
Arbitrary number of variables and contraints

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -14,7 +14,7 @@ jobs:
     steps:
     - uses: actions/checkout@v2
     - name: Install
-      run: rustup default nightly-2021-01-03
+      run: rustup default nightly-2021-01-31
     - name: Build
       run: cargo build --verbose
     - name: Run tests

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,7 +17,7 @@ rand = "0.7.3"
 digest = "0.8.1"
 sha3 = "0.8.2"
 byteorder = "1.3.4"
-rayon = "1.3.0"
+rayon = { version = "1.3.0", optional = true }
 serde = { version = "1.0.106", features = ["derive"] }
 bincode = "1.2.1"
 subtle = { version = "^2.2.3", default-features = false }
@@ -52,5 +52,5 @@ name = "nizk"
 harness = false
 
 [features]
-multicore = []
+multicore = ["rayon"]
 profile = []

--- a/README.md
+++ b/README.md
@@ -102,6 +102,7 @@ Here is another example to use the NIZK variant of the Spartan proof system:
 
 Finally, we provide an example that specifies a custom R1CS instance instead of using a synthetic instance
 ```rust
+#![allow(non_snake_case)]
 # extern crate curve25519_dalek;
 # extern crate libspartan;
 # extern crate merlin;

--- a/README.md
+++ b/README.md
@@ -164,7 +164,7 @@ Finally, we provide an example that specifies a custom R1CS instance instead of 
 
   // parameters of the R1CS instance rounded to the nearest power of two
   let num_cons = 4;
-  let num_vars = 8;
+  let num_vars = 5;
   let num_inputs = 2;
   let num_non_zero_entries = 8;
 

--- a/README.md
+++ b/README.md
@@ -166,7 +166,7 @@ Finally, we provide an example that specifies a custom R1CS instance instead of 
   let num_cons = 4;
   let num_vars = 5;
   let num_inputs = 2;
-  let num_non_zero_entries = 8;
+  let num_non_zero_entries = 5;
 
   // We will encode the above constraints into three matrices, where
   // the coefficients in the matrix are in the little-endian byte order

--- a/README.md
+++ b/README.md
@@ -82,7 +82,7 @@ Here is another example to use the NIZK variant of the Spartan proof system:
     let num_inputs = 10;
 
     // produce public parameters
-    let gens = NIZKGens::new(num_cons, num_vars);
+    let gens = NIZKGens::new(num_cons, num_vars, num_inputs);
 
     // ask the library to produce a synthentic R1CS instance
     let (inst, vars, inputs) = Instance::produce_synthetic_r1cs(num_cons, num_vars, num_inputs);

--- a/benches/nizk.rs
+++ b/benches/nizk.rs
@@ -24,7 +24,7 @@ fn nizk_prove_benchmark(c: &mut Criterion) {
 
     let (inst, vars, inputs) = Instance::produce_synthetic_r1cs(num_cons, num_vars, num_inputs);
 
-    let gens = NIZKGens::new(num_cons, num_vars);
+    let gens = NIZKGens::new(num_cons, num_vars, num_inputs);
 
     let name = format!("NIZK_prove_{}", num_vars);
     group.bench_function(&name, move |b| {
@@ -54,7 +54,7 @@ fn nizk_verify_benchmark(c: &mut Criterion) {
     let num_inputs = 10;
     let (inst, vars, inputs) = Instance::produce_synthetic_r1cs(num_cons, num_vars, num_inputs);
 
-    let gens = NIZKGens::new(num_cons, num_vars);
+    let gens = NIZKGens::new(num_cons, num_vars, num_inputs);
 
     // produce a proof of satisfiability
     let mut prover_transcript = Transcript::new(b"example");

--- a/profiler/nizk.rs
+++ b/profiler/nizk.rs
@@ -27,7 +27,7 @@ pub fn main() {
     let (inst, vars, inputs) = Instance::produce_synthetic_r1cs(num_cons, num_vars, num_inputs);
 
     // produce public generators
-    let gens = NIZKGens::new(num_cons, num_vars);
+    let gens = NIZKGens::new(num_cons, num_vars, num_inputs);
 
     // produce a proof of satisfiability
     let mut prover_transcript = Transcript::new(b"nizk_example");

--- a/src/dense_mlpoly.rs
+++ b/src/dense_mlpoly.rs
@@ -149,7 +149,7 @@ impl DensePolynomial {
     assert_eq!(L_size * R_size, self.Z.len());
     let C = (0..L_size)
       .into_par_iter()
-      .map(|&i| {
+      .map(|i| {
         self.Z[R_size * i..R_size * (i + 1)]
           .commit(&blinds[i], gens)
           .compress()

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -10,9 +10,11 @@ extern crate curve25519_dalek;
 extern crate digest;
 extern crate merlin;
 extern crate rand;
-extern crate rayon;
 extern crate sha3;
 extern crate test;
+
+#[cfg(feature = "multicore")]
+extern crate rayon;
 
 mod commitments;
 mod dense_mlpoly;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -31,8 +31,6 @@ mod timer;
 mod transcript;
 mod unipoly;
 
-use std::cmp::max;
-
 use errors::{ProofVerifyError, R1CSError};
 use merlin::Transcript;
 use r1csinstance::{

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -129,10 +129,8 @@ impl Instance {
       cons_pad = 2-num_cons.next_power_of_two();
     }
 
-    // check that the number of variables is a power of 2
-    if num_vars.next_power_of_two() != num_vars + vars_pad {
-      vars_pad = max(num_vars.next_power_of_two() - num_vars, vars_pad);
-    }
+    // Make num_vars a multiple of two
+    vars_pad += (num_vars + vars_pad).next_power_of_two() - (num_vars + vars_pad);
 
     let bytes_to_scalar =
       |tups: &Vec<(usize, usize, [u8; 32])>| -> Result<Vec<(usize, usize, Scalar)>, R1CSError> {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -284,6 +284,7 @@ pub struct SNARKGens {
 
 impl SNARKGens {
   /// Constructs a new `SNARKGens` given the size of the R1CS statement
+  /// `num_nz_entries` specifies the maximum number of non-zero entries in any of the three R1CS matrices
   pub fn new(num_cons: usize, num_vars: usize, num_inputs: usize, num_nz_entries: usize) -> Self {
     let num_vars_padded = {
       let mut num_vars_padded = max(num_vars, num_inputs + 1);

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -98,7 +98,7 @@ pub type InputsAssignment = Assignment;
 
 /// `Instance` holds the description of R1CS matrices
 pub struct Instance {
-  inst: R1CSInstance
+  inst: R1CSInstance,
 }
 
 impl Instance {
@@ -111,7 +111,6 @@ impl Instance {
     B: &Vec<(usize, usize, [u8; 32])>,
     C: &Vec<(usize, usize, [u8; 32])>,
   ) -> Result<Instance, R1CSError> {
-
     let mut vars_pad = 0;
     let mut cons_pad = 0;
 
@@ -126,7 +125,7 @@ impl Instance {
     }
 
     if num_cons.next_power_of_two() < 2 {
-      cons_pad = 2-num_cons.next_power_of_two();
+      cons_pad = 2 - num_cons.next_power_of_two();
     }
 
     // Make num_vars a multiple of two
@@ -192,11 +191,11 @@ impl Instance {
 
   // Work for any number of variables
   fn pad_variables(&self, vars: &Vec<Scalar>) -> Vec<Scalar> {
-      let vars_pad = self.inst.get_num_vars() - vars.len();
-      let mut padding = vec![Scalar::zero(); vars_pad];
-      let mut padded_assignment = vars.clone();
-      padded_assignment.append(&mut padding);
-      padded_assignment
+    let vars_pad = self.inst.get_num_vars() - vars.len();
+    let mut padding = vec![Scalar::zero(); vars_pad];
+    let mut padded_assignment = vars.clone();
+    padded_assignment.append(&mut padding);
+    padded_assignment
   }
 
   /// Checks if a given R1CSInstance is satisfiable with a given variables and inputs assignments
@@ -211,7 +210,11 @@ impl Instance {
 
     // Might need to create dummy variables
     if self.inst.get_num_vars() > vars.assignment.len() {
-      Ok(self.inst.is_sat(&self.pad_variables(&vars.assignment), &inputs.assignment))
+      Ok(
+        self
+          .inst
+          .is_sat(&self.pad_variables(&vars.assignment), &inputs.assignment),
+      )
     } else {
       Ok(self.inst.is_sat(&vars.assignment, &inputs.assignment))
     }
@@ -313,7 +316,6 @@ impl SNARK {
             transcript,
             &mut random_tape,
           );
-
 
       let proof_encoded: Vec<u8> = bincode::serialize(&proof).unwrap();
       Timer::print(&format!("len_r1cs_sat_proof {:?}", proof_encoded.len()));
@@ -591,11 +593,11 @@ mod tests {
     let mut C: Vec<(usize, usize, [u8; 32])> = Vec::new();
 
     // Create a^2 + b + 13
-    A.push((0, num_vars+2, Scalar::one().to_bytes())); // 1*a
-    B.push((0, num_vars+2, Scalar::one().to_bytes())); // 1*a
-    C.push((0, num_vars+1, Scalar::one().to_bytes())); // 1*z
+    A.push((0, num_vars + 2, Scalar::one().to_bytes())); // 1*a
+    B.push((0, num_vars + 2, Scalar::one().to_bytes())); // 1*a
+    C.push((0, num_vars + 1, Scalar::one().to_bytes())); // 1*z
     C.push((0, num_vars, (-Scalar::from(13u64)).to_bytes())); // -13*1
-    C.push((0, num_vars+3, (-Scalar::one()).to_bytes())); // -1*b
+    C.push((0, num_vars + 3, (-Scalar::one()).to_bytes())); // -1*b
 
     // Var Assignments (Z_0 = 16 is the only output)
     let vars = vec![Scalar::zero().to_bytes(); num_vars];

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -190,9 +190,12 @@ impl Instance {
           }
         }
 
-        // pad with additional constraints up until num_cons_padded
-        for i in tups.len()..num_cons_padded {
-          mat.push((i, num_vars, Scalar::zero()));
+        // pad with additional constraints up until num_cons_padded if the original constraints were 0 or 1
+        // we do not need to pad otherwise because the dummy constraints are implicit in the sum-check protocol
+        if num_cons == 0 || num_cons == 1 {
+          for i in tups.len()..num_cons_padded {
+            mat.push((i, num_vars, Scalar::zero()));
+          }
         }
 
         Ok(mat)

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -247,7 +247,7 @@ impl Instance {
       let num_padded_vars = self.inst.get_num_vars();
       let num_vars = vars.assignment.len();
       let padded_vars = if num_padded_vars > num_vars {
-        vars.pad(num_padded_vars - num_vars)
+        vars.pad(num_padded_vars)
       } else {
         vars.clone()
       };
@@ -285,7 +285,14 @@ pub struct SNARKGens {
 impl SNARKGens {
   /// Constructs a new `SNARKGens` given the size of the R1CS statement
   pub fn new(num_cons: usize, num_vars: usize, num_inputs: usize, num_nz_entries: usize) -> Self {
-    let num_vars_padded = max(num_vars, num_inputs + 1);
+    let num_vars_padded = {
+      let mut num_vars_padded = max(num_vars, num_inputs + 1);
+      if num_vars_padded != num_vars_padded.next_power_of_two() {
+        num_vars_padded = num_vars_padded.next_power_of_two();
+      }
+      num_vars_padded
+    };
+
     let gens_r1cs_sat = R1CSGens::new(b"gens_r1cs_sat", num_cons, num_vars_padded);
     let gens_r1cs_eval = R1CSCommitmentGens::new(
       b"gens_r1cs_eval",
@@ -350,7 +357,7 @@ impl SNARK {
           let num_padded_vars = inst.inst.get_num_vars();
           let num_vars = vars.assignment.len();
           let padded_vars = if num_padded_vars > num_vars {
-            vars.pad(num_padded_vars - num_vars)
+            vars.pad(num_padded_vars)
           } else {
             vars
           };

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -150,9 +150,9 @@ impl Instance {
           let val = Scalar::from_bytes(&val_bytes);
           if val.is_some().unwrap_u8() == 1 {
             if col >= num_vars {
-                mat.push((row, col + vars_pad, val.unwrap()));
+              mat.push((row, col + vars_pad, val.unwrap()));
             } else {
-                mat.push((row, col, val.unwrap()));
+              mat.push((row, col, val.unwrap()));
             }
           } else {
             return Err(R1CSError::InvalidScalar);

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -147,7 +147,11 @@ impl Instance {
 
           let val = Scalar::from_bytes(&val_bytes);
           if val.is_some().unwrap_u8() == 1 {
-            mat.push((row, col, val.unwrap()));
+            if col >= num_vars {
+                mat.push((row, col + vars_pad, val.unwrap()));
+            } else {
+                mat.push((row, col, val.unwrap()));
+            }
           } else {
             return Err(R1CSError::InvalidScalar);
           }

--- a/src/r1csproof.rs
+++ b/src/r1csproof.rs
@@ -14,7 +14,6 @@ use super::sparse_mlpoly::{SparsePolyEntry, SparsePolynomial};
 use super::sumcheck::ZKSumcheckInstanceProof;
 use super::timer::Timer;
 use super::transcript::{AppendToTranscript, ProofTranscript};
-use super::{InputsAssignment, Instance, SNARKGens, VarsAssignment, SNARK};
 use core::iter;
 use merlin::Transcript;
 use serde::{Deserialize, Serialize};
@@ -183,7 +182,6 @@ impl R1CSProof {
 
     // derive the verifier's challenge tau
     let (num_rounds_x, num_rounds_y) = (inst.get_num_cons().log2(), z.len().log2());
-
     let tau = transcript.challenge_vector(b"challenge_tau", num_rounds_x);
     // compute the initial evaluation table for R(\tau, x)
     let mut poly_tau = DensePolynomial::new(EqPolynomial::new(tau).evals());
@@ -575,7 +573,6 @@ mod tests {
     assert_eq!(is_sat, true);
   }
 
-
   #[test]
   pub fn check_r1cs_proof() {
     let num_vars = 1024;
@@ -608,69 +605,6 @@ mod tests {
         &mut verifier_transcript,
         &gens,
       )
-      .is_ok());
-  }
-
-  #[test]
-  fn test_padded_constraints() {
-    // parameters of the R1CS instance
-    let num_cons = 1;
-    let num_vars = 0;
-    let num_inputs = 3;
-    let num_non_zero_entries = 3;
-
-    // We will encode the above constraints into three matrices, where
-    // the coefficients in the matrix are in the little-endian byte order
-    let mut A: Vec<(usize, usize, [u8; 32])> = Vec::new();
-    let mut B: Vec<(usize, usize, [u8; 32])> = Vec::new();
-    let mut C: Vec<(usize, usize, [u8; 32])> = Vec::new();
-
-    // Create a^2 + b + 13
-    A.push((0, num_vars+2, Scalar::one().to_bytes())); // 1*a
-    B.push((0, num_vars+2, Scalar::one().to_bytes())); // 1*a
-    C.push((0, num_vars+1, Scalar::one().to_bytes())); // 1*z
-    C.push((0, num_vars, (-Scalar::from(13u64)).to_bytes())); // -13*1
-    C.push((0, num_vars+3, (-Scalar::one()).to_bytes())); // -1*b
-
-    // Var Assignments (Z_0 = 16 is the only output)
-    let vars = vec![Scalar::zero().to_bytes(); num_vars];
-
-    // create an InputsAssignment (a = 1, b = 2)
-    let mut inputs = vec![Scalar::zero().to_bytes(); num_inputs];
-    inputs[0] = Scalar::from(16u64).to_bytes();
-    inputs[1] = Scalar::from(1u64).to_bytes();
-    inputs[2] = Scalar::from(2u64).to_bytes();
-
-    // Now compute proof
-    let assignment_inputs = InputsAssignment::new(&inputs).unwrap();
-    let assignment_vars = VarsAssignment::new(&vars).unwrap();
-
-    // Check if instance is satisfiable
-    let inst = Instance::new(num_cons, num_vars, num_inputs, &A, &B, &C).unwrap();
-    let res = inst.is_sat(&assignment_vars, &assignment_inputs);
-    assert_eq!(res.unwrap(), true, "should be satisfied");
-
-    // Crypto proof public params
-    let gens = SNARKGens::new(num_cons, num_vars, num_inputs, num_non_zero_entries);
-
-    // create a commitment to the R1CS instance
-    let (comm, decomm) = SNARK::encode(&inst, &gens);
-
-    // produce a proof of satisfiability
-    let mut prover_transcript = Transcript::new(b"snark_example");
-    let proof = SNARK::prove(
-      &inst,
-      &decomm,
-      assignment_vars,
-      &assignment_inputs,
-      &gens,
-      &mut prover_transcript,
-    );
-
-    // verify the proof of satisfiability
-    let mut verifier_transcript = Transcript::new(b"snark_example");
-    assert!(proof
-      .verify(&comm, &assignment_inputs, &mut verifier_transcript, &gens)
       .is_ok());
   }
 }

--- a/src/r1csproof.rs
+++ b/src/r1csproof.rs
@@ -14,6 +14,7 @@ use super::sparse_mlpoly::{SparsePolyEntry, SparsePolynomial};
 use super::sumcheck::ZKSumcheckInstanceProof;
 use super::timer::Timer;
 use super::transcript::{AppendToTranscript, ProofTranscript};
+use super::{InputsAssignment, Instance, SNARKGens, VarsAssignment, SNARK};
 use core::iter;
 use merlin::Transcript;
 use serde::{Deserialize, Serialize};
@@ -182,6 +183,7 @@ impl R1CSProof {
 
     // derive the verifier's challenge tau
     let (num_rounds_x, num_rounds_y) = (inst.get_num_cons().log2(), z.len().log2());
+
     let tau = transcript.challenge_vector(b"challenge_tau", num_rounds_x);
     // compute the initial evaluation table for R(\tau, x)
     let mut poly_tau = DensePolynomial::new(EqPolynomial::new(tau).evals());
@@ -573,6 +575,7 @@ mod tests {
     assert_eq!(is_sat, true);
   }
 
+
   #[test]
   pub fn check_r1cs_proof() {
     let num_vars = 1024;
@@ -605,6 +608,69 @@ mod tests {
         &mut verifier_transcript,
         &gens,
       )
+      .is_ok());
+  }
+
+  #[test]
+  fn test_padded_constraints() {
+    // parameters of the R1CS instance
+    let num_cons = 1;
+    let num_vars = 0;
+    let num_inputs = 3;
+    let num_non_zero_entries = 3;
+
+    // We will encode the above constraints into three matrices, where
+    // the coefficients in the matrix are in the little-endian byte order
+    let mut A: Vec<(usize, usize, [u8; 32])> = Vec::new();
+    let mut B: Vec<(usize, usize, [u8; 32])> = Vec::new();
+    let mut C: Vec<(usize, usize, [u8; 32])> = Vec::new();
+
+    // Create a^2 + b + 13
+    A.push((0, num_vars+2, Scalar::one().to_bytes())); // 1*a
+    B.push((0, num_vars+2, Scalar::one().to_bytes())); // 1*a
+    C.push((0, num_vars+1, Scalar::one().to_bytes())); // 1*z
+    C.push((0, num_vars, (-Scalar::from(13u64)).to_bytes())); // -13*1
+    C.push((0, num_vars+3, (-Scalar::one()).to_bytes())); // -1*b
+
+    // Var Assignments (Z_0 = 16 is the only output)
+    let vars = vec![Scalar::zero().to_bytes(); num_vars];
+
+    // create an InputsAssignment (a = 1, b = 2)
+    let mut inputs = vec![Scalar::zero().to_bytes(); num_inputs];
+    inputs[0] = Scalar::from(16u64).to_bytes();
+    inputs[1] = Scalar::from(1u64).to_bytes();
+    inputs[2] = Scalar::from(2u64).to_bytes();
+
+    // Now compute proof
+    let assignment_inputs = InputsAssignment::new(&inputs).unwrap();
+    let assignment_vars = VarsAssignment::new(&vars).unwrap();
+
+    // Check if instance is satisfiable
+    let inst = Instance::new(num_cons, num_vars, num_inputs, &A, &B, &C).unwrap();
+    let res = inst.is_sat(&assignment_vars, &assignment_inputs);
+    assert_eq!(res.unwrap(), true, "should be satisfied");
+
+    // Crypto proof public params
+    let gens = SNARKGens::new(num_cons, num_vars, num_inputs, num_non_zero_entries);
+
+    // create a commitment to the R1CS instance
+    let (comm, decomm) = SNARK::encode(&inst, &gens);
+
+    // produce a proof of satisfiability
+    let mut prover_transcript = Transcript::new(b"snark_example");
+    let proof = SNARK::prove(
+      &inst,
+      &decomm,
+      assignment_vars,
+      &assignment_inputs,
+      &gens,
+      &mut prover_transcript,
+    );
+
+    // verify the proof of satisfiability
+    let mut verifier_transcript = Transcript::new(b"snark_example");
+    assert!(proof
+      .verify(&comm, &assignment_inputs, &mut verifier_transcript, &gens)
       .is_ok());
   }
 }


### PR DESCRIPTION
This commit makes adding an arbitrary number of variables and constraints possible.
This eliminates the assertions on number of constraints and number of variables imposed on user input.

  1. When creating a new R1CS Instance throught the public interface,
     it is required # constraints and # of vars be a power of 2. I remove
     that requirement by padding with dummy constraints and vars until the nearest
     power of 2.
  2. The sumcheck protocol in src/sumcheck.rs does not work for 1 constraint, even
     though 1 is a power of 2. I have to pad to a minimum of two constraints.
  3. Added a test in src/lib.rs called test_padded_constraints.