### PR TITLE
Remove extremely minor duplication

### DIFF
--- a/src/sparse_mlpoly.rs
+++ b/src/sparse_mlpoly.rs
@@ -380,8 +380,7 @@ impl SparseMatPolynomial {
     let N = (0..sparse_polys.len())
       .map(|i| sparse_polys[i].get_num_nz_entries())
       .max()
-      .unwrap()
-      .next_power_of_two();
+      .unwrap();
 
     let mut ops_row_vec: Vec<Vec<usize>> = Vec::new();
     let mut ops_col_vec: Vec<Vec<usize>> = Vec::new();


### PR DESCRIPTION
I noticed that the `next_power_of_two` call in the following code is redundant:

```
let N = (0..sparse_polys.len())
  .map(|i| sparse_polys[i].get_num_nz_entries())
  .max()
  .unwrap()
  .next_power_of_two();
```

Since `next_power_of_two` is already being called in the `get_num_nz_entries` method, it can be safely removed from this code without affecting performance. Therefore, I have made a pull request to remove this redundant call.

Thank you!