### PR TITLE
dense_mlpoly.rs: Fix manipulation of evaluation vector Z by bound functions

### DIFF
--- a/src/dense_mlpoly.rs
+++ b/src/dense_mlpoly.rs
@@ -216,6 +216,7 @@ impl DensePolynomial {
     for i in 0..n {
       self.Z[i] = self.Z[i] + r * (self.Z[i + n] - self.Z[i]);
     }
+    self.Z.truncate(n); // Resize the vector Z to the new length
     self.num_vars -= 1;
     self.len = n;
   }
@@ -225,6 +226,7 @@ impl DensePolynomial {
     for i in 0..n {
       self.Z[i] = self.Z[2 * i] + r * (self.Z[2 * i + 1] - self.Z[2 * i]);
     }
+    self.Z.truncate(n); // Resize the vector Z to the new length
     self.num_vars -= 1;
     self.len = n;
   }


### PR DESCRIPTION
The bound functions were folding the Z vector on itself but were not actually truncating it (even though they were changing self.len).

Hence, if you called a bound function and then evaluate() it would assert because evaluate() checks the size of the Z vector.

(PR copied from https://github.com/nexus-xyz/nexus-zkvm/pull/283)