### PR TITLE
docs: Fix grammatical error in initial comment

### DIFF
--- a/examples/cubic.rs
+++ b/examples/cubic.rs
@@ -1,4 +1,4 @@
-//! Demonstrates how to produces a proof for canonical cubic equation: `x^3 + x + 5 = y`.
+//! Demonstrates how to produce a proof for canonical cubic equation: `x^3 + x + 5 = y`.
 //! The example is described in detail [here].
 //!
 //! The R1CS for this problem consists of the following 4 constraints:


### PR DESCRIPTION
**Description:**
In the initial comment of the code, there was a small grammatical issue in the phrase:

```rust
//! Demonstrates how to produces a proof for canonical cubic equation: `x^3 + x + 5 = y`.
```

The word "produces" was incorrectly used. The corrected version should be "produce," as the sentence is describing the intended function of the code rather than the action of producing. The revised line is:

```rust
//! Demonstrates how to produce a proof for canonical cubic equation: `x^3 + x + 5 = y`.
```

While this was a minor issue, fixing it ensures the comment is clear and grammatically accurate, making the documentation easier to read and understand.